### PR TITLE
Updated 'captcha' spelling

### DIFF
--- a/include/youtube.php
+++ b/include/youtube.php
@@ -47,7 +47,7 @@ class youtube {
 
         if(strstr($html,'das_captcha'))
         {
-            $this->error = "Captcah Found please run on diffrent server";
+            $this->error = "Captcha Found please run on diffrent server";
             return false;
         }
 


### PR DESCRIPTION
The word `captcha` was spelt wrong in your code. Have corrected.
